### PR TITLE
Remove task-defining interfaces, and implement static creator methods

### DIFF
--- a/src/main/java/org/embulk/util/text/LineEncoder.java
+++ b/src/main/java/org/embulk/util/text/LineEncoder.java
@@ -24,10 +24,6 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigInject;
-import org.embulk.config.Task;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.FileOutput;
 import org.embulk.spi.util.FileOutputOutputStream;
@@ -35,30 +31,37 @@ import org.embulk.spi.util.FileOutputOutputStream;
 public class LineEncoder implements AutoCloseable {
     // TODO optimize
 
-    public LineEncoder(final FileOutput out, final EncoderTask task) {
-        this.newline = task.getNewline().getString();
-        this.underlyingFileOutput = out;
-        final CharsetEncoder encoder = task.getCharset()
+    private LineEncoder(
+            final FileOutput fileOutput,
+            final FileOutputOutputStream outputStream,
+            final String newline,
+            final BufferedWriter writer) {
+        this.underlyingFileOutput = fileOutput;
+        this.outputStream = outputStream;
+        this.newline = newline;
+        this.writer = writer;
+    }
+
+    public static LineEncoder of(
+            final FileOutput fileOutput,
+            final Newline newline,
+            final Charset charset,
+            final BufferAllocator bufferAllocator) {
+        final FileOutputOutputStream outputStream = new FileOutputOutputStream(
+                fileOutput, bufferAllocator, FileOutputOutputStream.CloseMode.FLUSH_FINISH);
+
+        final CharsetEncoder encoder = charset
                 .newEncoder()
                 .onMalformedInput(CodingErrorAction.REPLACE)  // TODO configurable?
                 .onUnmappableCharacter(CodingErrorAction.REPLACE);  // TODO configurable?
-        this.outputStream = new FileOutputOutputStream(
-                underlyingFileOutput, task.getBufferAllocator(), FileOutputOutputStream.CloseMode.FLUSH_FINISH);
 
-        this.writer = new BufferedWriter(new OutputStreamWriter(outputStream, encoder), 32 * 1024);
-    }
+        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, encoder), 32 * 1024);
 
-    public interface EncoderTask extends Task {
-        @Config("charset")
-        @ConfigDefault("\"utf-8\"")
-        Charset getCharset();
-
-        @Config("newline")
-        @ConfigDefault("\"CRLF\"")
-        Newline getNewline();
-
-        @ConfigInject
-        BufferAllocator getBufferAllocator();
+        return new LineEncoder(
+                fileOutput,
+                outputStream,
+                newline.getString(),
+                writer);
     }
 
     public void addNewLine() {

--- a/src/test/java/org/embulk/util/text/TestLineDecoder.java
+++ b/src/test/java/org/embulk/util/text/TestLineDecoder.java
@@ -26,10 +26,8 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
-import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.BufferImpl;
-import org.embulk.spi.Exec;
 import org.embulk.spi.util.ListFileInput;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,43 +36,13 @@ public class TestLineDecoder {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    @Test
-    public void testDefaultValues() {
-        ConfigSource config = Exec.newConfigSource();
-        LineDecoder.DecoderTask task = config.loadConfig(LineDecoder.DecoderTask.class);
-        assertEquals(StandardCharsets.UTF_8, task.getCharset());
-        assertEquals(Newline.CRLF, task.getNewline());
-    }
-
-    @Test
-    public void testLoadConfig() {
-        ConfigSource config = Exec.newConfigSource()
-                .set("charset", "utf-16")
-                .set("newline", "CRLF")
-                .set("line_delimiter_recognized", "LF");
-        LineDecoder.DecoderTask task = config.loadConfig(LineDecoder.DecoderTask.class);
-        assertEquals(StandardCharsets.UTF_16, task.getCharset());
-        assertEquals(Newline.CRLF, task.getNewline());
-        assertEquals(LineDelimiter.LF, task.getLineDelimiterRecognized().get());
-    }
-
-    private static LineDecoder.DecoderTask getExampleConfig(Charset charset, Newline newline, LineDelimiter lineDelimiter) {
-        ConfigSource config = Exec.newConfigSource()
-                .set("charset", charset)
-                .set("newline", newline);
-        if (lineDelimiter != null) {
-            config.set("line_delimiter_recognized", lineDelimiter);
-        }
-        return config.loadConfig(LineDecoder.DecoderTask.class);
-    }
-
     private static LineDecoder newDecoder(Charset charset, Newline newline, List<Buffer> buffers) {
         return newDecoder(charset, newline, null, buffers);
     }
 
     private static LineDecoder newDecoder(Charset charset, Newline newline, LineDelimiter lineDelimiter, List<Buffer> buffers) {
         ListFileInput input = new ListFileInput(ImmutableList.of(buffers));
-        return new LineDecoder(input, getExampleConfig(charset, newline, lineDelimiter));
+        return LineDecoder.of(input, charset, lineDelimiter);
     }
 
     private static List<String> doDecode(Charset charset, Newline newline, List<Buffer> buffers) {

--- a/src/test/java/org/embulk/util/text/TestLineEncoder.java
+++ b/src/test/java/org/embulk/util/text/TestLineEncoder.java
@@ -17,6 +17,8 @@
 package org.embulk.util.text;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
@@ -30,18 +32,15 @@ public class TestLineEncoder {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    private LineEncoder newEncoder(String charset, String newline,
+    private LineEncoder newEncoder(Charset charset, Newline newline,
             FileOutput output) throws Exception {
-        ConfigSource config = Exec.newConfigSource()
-                .set("charset", charset)
-                .set("newline", newline);
-        return new LineEncoder(output, config.loadConfig(LineEncoder.EncoderTask.class));
+        return LineEncoder.of(output, newline, charset, Exec.getBufferAllocator());
     }
 
     @Test
     public void testAddLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
-            LineEncoder encoder = newEncoder("utf-8", "LF", output);
+            LineEncoder encoder = newEncoder(StandardCharsets.UTF_8, Newline.LF, output);
             encoder.nextFile();
             for (String line : new String[] { "abc", "日本語(Japanese)" }) {
                 encoder.addLine(line);
@@ -60,7 +59,7 @@ public class TestLineEncoder {
     @Test
     public void testAddTextAddNewLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
-            LineEncoder encoder = newEncoder("utf-8", "LF", output);
+            LineEncoder encoder = newEncoder(StandardCharsets.UTF_8, Newline.LF, output);
             encoder.nextFile();
             for (String line : new String[] { "abc", "日本語(Japanese)" }) {
                 encoder.addText(line);
@@ -80,7 +79,7 @@ public class TestLineEncoder {
     @Test
     public void testNewLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
-            LineEncoder encoder = newEncoder("utf-8", "CRLF", output);
+            LineEncoder encoder = newEncoder(StandardCharsets.UTF_8, Newline.CRLF, output);
             encoder.nextFile();
             for (String line : new String[] { "abc", "日本語(Japanese)" }) {
                 encoder.addLine(line);
@@ -99,7 +98,7 @@ public class TestLineEncoder {
     @Test
     public void testCharset() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
-            LineEncoder encoder = newEncoder("MS932", "CR", output);
+            LineEncoder encoder = newEncoder(Charset.forName("MS932"), Newline.CR, output);
             encoder.nextFile();
             for (String line : new String[] { "abc", "日本語(Japanese)" }) {
                 encoder.addLine(line);


### PR DESCRIPTION
`LineDecoder` and `LineEncoder` have their own "task-defining interfaces", such as `LineDecoder.DecoderTask`, but it causes a strong dependency on `embulk-core`, its configuration loading mechanism, and Jackson. We have to eliminate such dependencies, especially related to Jackson.

Then, we remove those "task-defining interfaces" from this library. Users of this library would need to define their own task-defining interface, and create `LineDecoder` or `LineEncoder` instances by themselves.