### PR TITLE
Stop depending on embulk-core, and start depending on embulk-util-file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ repositories {
 
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.8"
-    compileOnly "org.embulk:embulk-core:0.10.8"
+
+    api "org.embulk:embulk-util-file:0.1.0"
 
     testImplementation "junit:junit:4.13"
     testImplementation "org.embulk:embulk-api:0.10.8"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,27 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-aopalliance:aopalliance:1.0
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
-com.fasterxml.jackson.module:jackson-module-guice:2.6.7
-com.google.guava:guava:18.0
-com.google.inject.extensions:guice-multibindings:4.0
-com.google.inject:guice:4.0
-commons-beanutils:commons-beanutils-core:1.8.3
-javax.inject:javax.inject:1
-javax.validation:validation-api:1.1.0.Final
-joda-time:joda-time:2.9.2
-org.apache.bval:bval-core:0.5
-org.apache.bval:bval-jsr303:0.5
-org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.8
-org.embulk:embulk-core:0.10.8
-org.embulk:embulk-spi:0.10.8
-org.jruby:jruby-complete:9.1.15.0
-org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.embulk:embulk-util-file:0.1.0

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,3 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-file:0.1.0

--- a/src/main/java/org/embulk/util/text/LineDecoder.java
+++ b/src/main/java/org/embulk/util/text/LineDecoder.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.embulk.spi.FileInput;
-import org.embulk.spi.util.FileInputInputStream;
+import org.embulk.util.file.FileInputInputStream;
 
 public class LineDecoder implements AutoCloseable, Iterable<String> {
     // TODO optimize

--- a/src/main/java/org/embulk/util/text/LineEncoder.java
+++ b/src/main/java/org/embulk/util/text/LineEncoder.java
@@ -26,7 +26,7 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.FileOutput;
-import org.embulk.spi.util.FileOutputOutputStream;
+import org.embulk.util.file.FileOutputOutputStream;
 
 public class LineEncoder implements AutoCloseable {
     // TODO optimize


### PR DESCRIPTION
It is still using `embulk-core`'s `FileInputInputStream` and `FileOutputOutputStream`, but they are now exported to another library https://github.com/embulk/embulk-util-file.

It should use `embulk-util-file` instead of `embulk-core`'s.