### PR TITLE
Add minimum Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,9 @@ javadoc {
     options {
         locale = "en_US"
         encoding = "UTF-8"
+        overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
+        links "https://dev.embulk.org/embulk-api/0.10.8/javadoc/"
     }
 }
 

--- a/src/main/html/overview.html
+++ b/src/main/html/overview.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>embulk-util-text</title>
+  </head>
+  <body>
+    <p>Embulk text processor for Embulk plugins.</p>
+  </body>
+</html>

--- a/src/main/java/org/embulk/util/text/LineDecoder.java
+++ b/src/main/java/org/embulk/util/text/LineDecoder.java
@@ -30,6 +30,14 @@ import java.util.Optional;
 import org.embulk.spi.FileInput;
 import org.embulk.util.file.FileInputInputStream;
 
+/**
+ * Decodes {@link org.embulk.spi.FileInput} into iteration of lines.
+ *
+ * <p>Unlike {@code embulk-core}'s {@code org.embulk.spi.util.LineDecoder}, it does not receive a task-defining
+ * interface like {@code DecoderTask}. Use {@link #of(FileInput, Charset, LineDelimiter)} instead.
+ *
+ * <pre><code>LineDecoder decoder = LineDecoder.of(fileInput, charset, null);</code></pre>
+ */
 public class LineDecoder implements AutoCloseable, Iterable<String> {
     // TODO optimize
 

--- a/src/main/java/org/embulk/util/text/LineEncoder.java
+++ b/src/main/java/org/embulk/util/text/LineEncoder.java
@@ -28,6 +28,14 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.FileOutput;
 import org.embulk.util.file.FileOutputOutputStream;
 
+/**
+ * Encodes {@link java.io.BufferedWriter} as iteration of lines into {@link org.embulk.spi.FileOutput}.
+ *
+ * <p>Unlike {@code embulk-core}'s {@code org.embulk.spi.util.LineEncoder}, it does not receive a task-defining
+ * interface like {@code EncoderTask}. Use {@link #of(FileOutput, Newline, Charset, BufferAllocator)} instead.
+ *
+ * <pre><code>LineEncoder encoder = LineEncoder.of(fileOutput, newline, charset, Exec.getBufferAllocator());</code></pre>
+ */
 public class LineEncoder implements AutoCloseable {
     // TODO optimize
 


### PR DESCRIPTION
Adding minimum required Javadoc just how to instantiate `LineDecoder` and `LineEncoder`.

(Remaining Javadocs are issued #10.)